### PR TITLE
Fix memory leak

### DIFF
--- a/src/main/java/de/tubeof/tubetils/api/actionbar/events/ActionBarMessageDurationEvent.java
+++ b/src/main/java/de/tubeof/tubetils/api/actionbar/events/ActionBarMessageDurationEvent.java
@@ -7,7 +7,7 @@ import org.bukkit.event.HandlerList;
 @SuppressWarnings("ALL")
 public class ActionBarMessageDurationEvent extends Event {
 
-    private final HandlerList handlers = new HandlerList();
+    private static final HandlerList handlers = new HandlerList();
     private final Player player;
     private String message;
     private Boolean cancelled;
@@ -43,5 +43,9 @@ public class ActionBarMessageDurationEvent extends Event {
 
     public void setCancelled(boolean cancelled) {
         this.cancelled = cancelled;
+    }
+
+    public static HandlerList getHandlerList() {
+        return handlers;
     }
 }

--- a/src/main/java/de/tubeof/tubetils/api/actionbar/events/ActionBarMessageEvent.java
+++ b/src/main/java/de/tubeof/tubetils/api/actionbar/events/ActionBarMessageEvent.java
@@ -7,7 +7,7 @@ import org.bukkit.event.HandlerList;
 @SuppressWarnings("ALL")
 public class ActionBarMessageEvent extends Event {
 
-    private final HandlerList handlers = new HandlerList();
+    private static final HandlerList handlers = new HandlerList();
     private final Player player;
     private String message;
     private Boolean cancelled;
@@ -41,5 +41,9 @@ public class ActionBarMessageEvent extends Event {
 
     public void setCancelled(boolean cancelled) {
         this.cancelled = cancelled;
+    }
+
+    public static HandlerList getHandlerList() {
+        return handlers;
     }
 }

--- a/src/main/java/de/tubeof/tubetils/api/cache/events/CacheContainerAddEvent.java
+++ b/src/main/java/de/tubeof/tubetils/api/cache/events/CacheContainerAddEvent.java
@@ -5,7 +5,7 @@ import org.bukkit.event.HandlerList;
 
 public class CacheContainerAddEvent extends Event {
 
-    private final HandlerList handlers = new HandlerList();
+    private static final HandlerList handlers = new HandlerList();
 
     public CacheContainerAddEvent() {}
 
@@ -14,4 +14,7 @@ public class CacheContainerAddEvent extends Event {
         return this.handlers;
     }
 
+    public static HandlerList getHandlerList() {
+        return handlers;
+    }
 }

--- a/src/main/java/de/tubeof/tubetils/api/cache/events/CacheContainerGetEvent.java
+++ b/src/main/java/de/tubeof/tubetils/api/cache/events/CacheContainerGetEvent.java
@@ -5,7 +5,7 @@ import org.bukkit.event.HandlerList;
 
 public class CacheContainerGetEvent extends Event {
 
-    private final HandlerList handlers = new HandlerList();
+    private static final HandlerList handlers = new HandlerList();
 
     public CacheContainerGetEvent() {}
 
@@ -14,4 +14,7 @@ public class CacheContainerGetEvent extends Event {
         return this.handlers;
     }
 
+    public static HandlerList getHandlerList() {
+        return handlers;
+    }
 }

--- a/src/main/java/de/tubeof/tubetils/api/cache/events/CacheContainerRegisterTypeEvent.java
+++ b/src/main/java/de/tubeof/tubetils/api/cache/events/CacheContainerRegisterTypeEvent.java
@@ -5,7 +5,7 @@ import org.bukkit.event.HandlerList;
 
 public class CacheContainerRegisterTypeEvent extends Event {
 
-    private final HandlerList handlers = new HandlerList();
+    private static final HandlerList handlers = new HandlerList();
     private final  Class typeClass;
 
     public CacheContainerRegisterTypeEvent(Class typeClass) {
@@ -21,4 +21,7 @@ public class CacheContainerRegisterTypeEvent extends Event {
         return this.typeClass;
     }
 
+    public static HandlerList getHandlerList() {
+        return handlers;
+    }
 }

--- a/src/main/java/de/tubeof/tubetils/api/packetscoreboard/events/PacketScoreboardDeleteEvent.java
+++ b/src/main/java/de/tubeof/tubetils/api/packetscoreboard/events/PacketScoreboardDeleteEvent.java
@@ -6,7 +6,7 @@ import org.bukkit.event.HandlerList;
 
 public class PacketScoreboardDeleteEvent extends Event {
 
-    private final HandlerList handlers = new HandlerList();
+    private static final HandlerList handlers = new HandlerList();
     private final Player player;
 
     public PacketScoreboardDeleteEvent(Player player) {
@@ -22,4 +22,7 @@ public class PacketScoreboardDeleteEvent extends Event {
         return this.player;
     }
 
+    public static HandlerList getHandlerList() {
+        return handlers;
+    }
 }

--- a/src/main/java/de/tubeof/tubetils/api/packetscoreboard/events/PacketScoreboardSendEvent.java
+++ b/src/main/java/de/tubeof/tubetils/api/packetscoreboard/events/PacketScoreboardSendEvent.java
@@ -6,7 +6,7 @@ import org.bukkit.event.HandlerList;
 
 public class PacketScoreboardSendEvent extends Event {
 
-    private final HandlerList handlers = new HandlerList();
+    private static final HandlerList handlers = new HandlerList();
     private final Player player;
     private Boolean cancelled;
 
@@ -32,4 +32,7 @@ public class PacketScoreboardSendEvent extends Event {
         this.cancelled = cancelled;
     }
 
+    public static HandlerList getHandlerList() {
+        return handlers;
+    }
 }

--- a/src/main/java/de/tubeof/tubetils/api/packetscoreboard/events/PacketScoreboardUpdateEvent.java
+++ b/src/main/java/de/tubeof/tubetils/api/packetscoreboard/events/PacketScoreboardUpdateEvent.java
@@ -6,7 +6,7 @@ import org.bukkit.event.HandlerList;
 
 public class PacketScoreboardUpdateEvent extends Event {
 
-    private final HandlerList handlers = new HandlerList();
+    private static final HandlerList handlers = new HandlerList();
     private final Player player;
 
     public PacketScoreboardUpdateEvent(Player player) {
@@ -22,4 +22,7 @@ public class PacketScoreboardUpdateEvent extends Event {
         return this.player;
     }
 
+    public static HandlerList getHandlerList() {
+        return handlers;
+    }
 }

--- a/src/main/java/de/tubeof/tubetils/api/title/events/TitleClearEvent.java
+++ b/src/main/java/de/tubeof/tubetils/api/title/events/TitleClearEvent.java
@@ -6,7 +6,7 @@ import org.bukkit.event.HandlerList;
 
 public class TitleClearEvent extends Event {
 
-    private final HandlerList handlers = new HandlerList();
+    private static final HandlerList handlers = new HandlerList();
     private final Player player;
     private Boolean cancelled;
 
@@ -32,4 +32,7 @@ public class TitleClearEvent extends Event {
         this.cancelled = cancelled;
     }
 
+    public static HandlerList getHandlerList() {
+        return handlers;
+    }
 }

--- a/src/main/java/de/tubeof/tubetils/api/title/events/TitleSendEvent.java
+++ b/src/main/java/de/tubeof/tubetils/api/title/events/TitleSendEvent.java
@@ -6,7 +6,7 @@ import org.bukkit.event.HandlerList;
 
 public class TitleSendEvent extends Event {
 
-    private final HandlerList handlers = new HandlerList();
+    private static final HandlerList handlers = new HandlerList();
     private final Player player;
     private String title;
     private String subtitle;
@@ -52,4 +52,7 @@ public class TitleSendEvent extends Event {
         this.cancelled = cancelled;
     }
 
+    public static HandlerList getHandlerList() {
+        return handlers;
+    }
 }


### PR DESCRIPTION
Closes #1.

Whenever an event in this library is initialised, a `new HandlerList()` is allocated on the heap and in the constructor it is added to a static ArrayList. This fix makes all HandlerLists static and also adds a static `getHandlerList()` method, as required by the Event class.